### PR TITLE
Update to build otelcol binary, then add to the image

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -12,6 +12,11 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: OCB Build
+        run: |
+             chmod +x "${GITHUB_WORKSPACE}/builder.sh"
+             ${GITHUB_WORKSPACE}/builder.sh
+
     - name: Buildah Build
       id: build-image
       uses: redhat-actions/buildah-build@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+ocb
+otel-collector-image
+tmp
+temp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM fedora:latest
 
 RUN dnf -y update && \
 	mkdir -p /usr/local/bin
- 
-ADD builder-config.yaml /usr/local/bin/builder-config.yaml
-ADD builder.sh /usr/local/bin/builder.sh
 
-RUN chmod +x /usr/local/bin/builder.sh
+VOLUME /etc/otelcol-contrib
+ADD otel-collector-image/otel-collector-image /usr/local/bin/otel-collector-sp
 
+# Debug stuff...
 #ENTRYPOINT /bin/bash
-ENTRYPOINT /bin/bash -l /usr/local/bin/builder.sh
+#ENTRYPOINT /usr/local/bin/otel-collector-sp
+
+CMD ["/usr/local/bin/otel-collector-sp", "--config", "/etc/otelcol-contrib/config.yaml"]
+

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -2,23 +2,25 @@ dist:
   name: otel-collector-image
   description: Custom OTel collector image
   output_path: ./otel-collector-image
-  otelcol_version: 0.88.0
+  otelcol_version: 0.91.0
 receivers:
   - gomod:
-      go.opentelemetry.io/collector/receiver/otlpreceiver v0.88.0
+      go.opentelemetry.io/collector/receiver/otlpreceiver v0.91.0
   - gomod:
-      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver v0.88.0
+      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver v0.91.0
 
 processors:
   - gomod:
-      go.opentelemetry.io/collector/processor/batchprocessor v0.88.0
+      go.opentelemetry.io/collector/processor/batchprocessor v0.91.0
   - gomod:
-     go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.88.0
+     go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.91.0
 
 exporters:
   - gomod:
-      go.opentelemetry.io/collector/exporter/otlpexporter v0.88.0
+      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.91.0
   - gomod:
-      go.opentelemetry.io/collector/exporter/otlphttpexporter v0.88.0
+      go.opentelemetry.io/collector/exporter/otlpexporter v0.91.0
   - gomod:
-      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.88.0
+      go.opentelemetry.io/collector/exporter/otlphttpexporter v0.91.0
+  - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.91.0

--- a/builder.sh
+++ b/builder.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-sudo wget https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv0.88.0/ocb_0.88.0_darwin_amd64 
-mv ocb_0.88.0_darwin_amd64 ocb
-sudo chmod 777 ocb
+# MacOS
+wget -O ocb https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv0.88.0/ocb_0.91.0_darwin_amd64 
+
+# Linux x64
+#wget -O ocb https://github.com/open-telemetry/opentelemetry-collector/releases/download/cmd%2Fbuilder%2Fv0.91.0/ocb_0.91.0_linux_amd64
+
+chmod +x ocb
 ./ocb --config builder-config.yaml


### PR DESCRIPTION
This changes the GHA build approach to execute the builder.sh 'locally' in the pipeline, then make that available to the Dockerfile. The Dockerfile is changed to use the same configuration defaults as the 'vanilla' otelcol-contrib, and checked to make sure it'll boot.

Finally, the otelcol version has been upgraded to 0.91.0.